### PR TITLE
ci: use RELEASE_PLEASE_TOKEN PAT so releases trigger publish.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,13 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Use a PAT so the tag push + release-create events are
+          # attributed to a user identity, not the default
+          # GITHUB_TOKEN.  GitHub deliberately suppresses workflow
+          # triggers from GITHUB_TOKEN to prevent loops, which is
+          # why publish.yml needed manual `gh workflow run` in
+          # v0.0.6.  Falls back to GITHUB_TOKEN when the secret
+          # is absent so the workflow still runs in forks.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

release-please creates the v* GitHub Release using the default
`GITHUB_TOKEN`. GitHub deliberately suppresses workflow triggers from
that token to prevent action-on-action loops, which is why
`publish.yml` did not auto-fire on `release: published` for v0.0.6 and
needed `gh workflow run publish.yml --ref main` manually.

This PR passes a fine-grained PAT (`RELEASE_PLEASE_TOKEN`) to the
release-please action via its `token:` input. Tag pushes + release
creation are then attributed to a user identity, which **does**
trigger downstream workflows. Future releases publish to PyPI
automatically.

The workflow falls back to `GITHUB_TOKEN` if the secret is absent,
so forks without the PAT still get a working release-please run.

## Test plan

- [x] PAT created with `Contents: rw` + `Pull requests: rw`
- [x] `RELEASE_PLEASE_TOKEN` set via `gh secret set`
- [ ] PR merged
- [ ] Next release-please cycle (v0.0.7) auto-publishes to PyPI
      without manual `gh workflow run`