### PR TITLE
build(deps): ignore provider-SDK + textual majors as singletons

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,33 @@ updates:
       # the Space is smoke-tested.
       - dependency-name: "gradio"
         update-types: ["version-update:semver-major"]
+      # Provider-SDK major bumps need source rewrites — mistralai
+      # 2.x removed the top-level `Mistral` symbol, openai 2.x
+      # reshaped response types, cohere 5→7 changed message
+      # typing, groq 0.x → 1.x reshaped the client.  The group
+      # rule above only restricts the *grouped* bump shape;
+      # individual single-package PRs need explicit ignores too.
+      # Drop these when the matching provider module is rewritten
+      # against the new SDK.
+      - dependency-name: "openai"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "anthropic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "google-generativeai"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mistralai"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "cohere"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "huggingface_hub"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "groq"
+        update-types: ["version-update:semver-major"]
+      # textual 1.0 reshaped reactive bindings; the TUI surface
+      # was written against the 0.80 line.  Drop when the TUI is
+      # re-verified against the next major.
+      - dependency-name: "textual"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

PR #31 only restricted the group bump shape. Dependabot then
opened five single-package PRs for the same majors (#32 openai,
#33 groq, #34 mistralai, #35 cohere, #36 textual). Add top-level
`version-update:semver-major` ignores for every member of the
provider-sdks group + textual so individual majors stop showing
up too.

Each ignore carries a one-line "drop when…" comment so a future
maintainer knows how to lift it.